### PR TITLE
Upgrade to use jsonpath-plus for additional selector support

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ json-schema-spell-checker -f 'description,title' /path/to/openapi.json
 Alternatively, you can specify a JSONPath expression yourself
 
 ```bash
-json-schema-spell-checker -j '$..["description","title"]' /path/to/openapi.json
+json-schema-spell-checker -j "$..[description,title]" /path/to/openapi.json
 ```
 
 If you have words that aren't a spelling mistake but aren't in the dictionary, add them to a `.spelling` file (one word per line) in the current folder. Alternatively, you can provide a path with `-s`
@@ -29,4 +29,3 @@ If you have words that aren't a spelling mistake but aren't in the dictionary, a
 ```bash
 json-schema-spell-checker -s /path/to/.spelling -f 'description,title' /path/to/openapi.json
 ```
-

--- a/extract.js
+++ b/extract.js
@@ -1,4 +1,4 @@
-var jp = require("jsonpath");
+var { JSONPath } = require("jsonpath-plus");
 
 /**
  * Extracts all titles and descriptions from a specification
@@ -8,15 +8,17 @@ const extract = (document, fields = []) => {
   if (typeof fields == "string") {
     path = fields;
   } else {
-    fields = fields.map(f => `'${f}'`);
     path = `$..[${fields.join(",")}]`;
   }
 
-  const nodes = jp.nodes(document, path);
-  return nodes.map(n => {
-    n.path = jp.stringify(n.path);
-    return n;
-  });
+  return JSONPath({ path, json: document, resultType: "all" }).map(
+    ({ path, value }) => {
+      return {
+        path,
+        value
+      };
+    }
+  );
 };
 
 module.exports = extract;

--- a/extract.test.js
+++ b/extract.test.js
@@ -15,25 +15,25 @@ const json = [
 
 test("matches a single field", () => {
   expect(extract(json, ["title"])).toEqual([
-    { path: "$[0].title", value: "This is the first item" },
-    { path: "$[1].title", value: "This is the second item" }
+    { path: "$[0]['title']", value: "This is the first item" },
+    { path: "$[1]['title']", value: "This is the second item" }
   ]);
 });
 
 test("matches a multiple fields", () => {
   expect(extract(json, ["title", "position"])).toEqual([
-    { path: "$.value[0].title", value: "This is the first item" },
-    { path: "$.value[0].position", value: 1 },
-    { path: "$.value[1].title", value: "This is the second item" },
-    { path: "$.value[1].position", value: 2 }
+    { path: "$[0]['title']", value: "This is the first item" },
+    { path: "$[0]['position']", value: 1 },
+    { path: "$[1]['title']", value: "This is the second item" },
+    { path: "$[1]['position']", value: 2 }
   ]);
 });
 
 test("respects the JSONPath ordering", () => {
   expect(extract(json, ["position", "title"])).toEqual([
-    { path: "$.value[0].position", value: 1 },
-    { path: "$.value[0].title", value: "This is the first item" },
-    { path: "$.value[1].position", value: 2 },
-    { path: "$.value[1].title", value: "This is the second item" }
+    { path: "$[0]['position']", value: 1 },
+    { path: "$[0]['title']", value: "This is the first item" },
+    { path: "$[1]['position']", value: 2 },
+    { path: "$[1]['title']", value: "This is the second item" }
   ]);
 });

--- a/index.test.js
+++ b/index.test.js
@@ -20,13 +20,13 @@ test("checker run one", async () => {
   expect(actual).toEqual([
     {
       errors: [{ index: 0, word: "Speling" }],
-      path: "$[0].title",
+      path: "$[0]['title']",
       value: "Speling mistake here",
       plain: "Speling mistake here"
     },
     {
       errors: [{ index: 4, word: "ther" }],
-      path: "$[1].nested.title",
+      path: "$[1]['nested']['title']",
       value: "But ther is one in nested",
       plain: "But ther is one in nested"
     }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "oas-spell-checker",
+  "name": "json-schema-spell-checker",
   "version": "1.0.3",
   "lockfileVersion": 1,
   "requires": true,
@@ -1411,7 +1411,8 @@
     "deep-is": {
       "version": "0.1.3",
       "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz",
-      "integrity": "sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ="
+      "integrity": "sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ=",
+      "dev": true
     },
     "define-properties": {
       "version": "1.1.3",
@@ -1571,6 +1572,7 @@
       "version": "1.12.0",
       "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-1.12.0.tgz",
       "integrity": "sha512-TuA+EhsanGcme5T3R0L80u4t8CpbXQjegRmf7+FPTJrtCTErXFeelblRgHQa1FofEzqYYJmJ/OqjTwREp9qgmg==",
+      "dev": true,
       "requires": {
         "esprima": "^3.1.3",
         "estraverse": "^4.2.0",
@@ -1582,7 +1584,8 @@
         "esprima": {
           "version": "3.1.3",
           "resolved": "https://registry.npmjs.org/esprima/-/esprima-3.1.3.tgz",
-          "integrity": "sha1-/cpRzuYTOJXjyI1TXOSdv/YqRjM="
+          "integrity": "sha1-/cpRzuYTOJXjyI1TXOSdv/YqRjM=",
+          "dev": true
         }
       }
     },
@@ -1904,12 +1907,14 @@
     "estraverse": {
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.3.0.tgz",
-      "integrity": "sha512-39nnKffWz8xN1BU/2c79n9nB9HDzo0niYUqx6xyqUnyoAnQyyWpOTdZEeiCch8BBu515t4wp9ZmgVfVhn9EBpw=="
+      "integrity": "sha512-39nnKffWz8xN1BU/2c79n9nB9HDzo0niYUqx6xyqUnyoAnQyyWpOTdZEeiCch8BBu515t4wp9ZmgVfVhn9EBpw==",
+      "dev": true
     },
     "esutils": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
-      "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g=="
+      "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
+      "dev": true
     },
     "exec-sh": {
       "version": "0.3.4",
@@ -2120,7 +2125,8 @@
     "fast-levenshtein": {
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
-      "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc="
+      "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=",
+      "dev": true
     },
     "fb-watchman": {
       "version": "2.0.1",
@@ -4359,22 +4365,10 @@
         "minimist": "^1.2.0"
       }
     },
-    "jsonpath": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/jsonpath/-/jsonpath-1.0.2.tgz",
-      "integrity": "sha512-rmzlgFZiQPc6q4HDyK8s9Qb4oxBnI5sF61y/Co5PV0lc3q2bIuRsNdueVbhoSHdKM4fxeimphOAtfz47yjCfeA==",
-      "requires": {
-        "esprima": "1.2.2",
-        "static-eval": "2.0.2",
-        "underscore": "1.7.0"
-      },
-      "dependencies": {
-        "esprima": {
-          "version": "1.2.2",
-          "resolved": "https://registry.npmjs.org/esprima/-/esprima-1.2.2.tgz",
-          "integrity": "sha1-dqD9Zvz+FU/SkmZ9wmQBl1CxZXs="
-        }
-      }
+    "jsonpath-plus": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/jsonpath-plus/-/jsonpath-plus-4.0.0.tgz",
+      "integrity": "sha512-e0Jtg4KAzDJKKwzbLaUtinCn0RZseWBVRTRGihSpvFlM3wTR7ExSp+PTdeTsDrLNJUe7L7JYJe8mblHX5SCT6A=="
     },
     "jsprim": {
       "version": "1.4.1",
@@ -4416,6 +4410,7 @@
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/levn/-/levn-0.3.0.tgz",
       "integrity": "sha1-OwmSTt+fCDwEkP3UwLxEIeBHZO4=",
+      "dev": true,
       "requires": {
         "prelude-ls": "~1.1.2",
         "type-check": "~0.3.2"
@@ -4940,6 +4935,7 @@
       "version": "0.8.3",
       "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.8.3.tgz",
       "integrity": "sha512-+IW9pACdk3XWmmTXG8m3upGUJst5XRGzxMRjXzAuJ1XnIFNvfhjjIuYkDvysnPQ7qzqVzLt78BCruntqRhWQbA==",
+      "dev": true,
       "requires": {
         "deep-is": "~0.1.3",
         "fast-levenshtein": "~2.0.6",
@@ -5145,7 +5141,8 @@
     "prelude-ls": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz",
-      "integrity": "sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ="
+      "integrity": "sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ=",
+      "dev": true
     },
     "prettier": {
       "version": "1.19.1",
@@ -5807,7 +5804,8 @@
     "source-map": {
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
+      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+      "dev": true
     },
     "source-map-resolve": {
       "version": "0.5.2",
@@ -5920,14 +5918,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/state-toggle/-/state-toggle-1.0.2.tgz",
       "integrity": "sha512-8LpelPGR0qQM4PnfLiplOQNJcIN1/r2Gy0xKB2zKnIW2YzPMt2sR4I/+gtPjhN7Svh9kw+zqEg2SFwpBO9iNiw=="
-    },
-    "static-eval": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/static-eval/-/static-eval-2.0.2.tgz",
-      "integrity": "sha512-N/D219Hcr2bPjLxPiV+TQE++Tsmrady7TqAJugLy7Xk1EumfDWS/f5dtBbkRCGE7wKKXuYockQoj8Rm2/pVKyg==",
-      "requires": {
-        "escodegen": "^1.8.1"
-      }
     },
     "static-extend": {
       "version": "0.1.2",
@@ -6282,6 +6272,7 @@
       "version": "0.3.2",
       "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.3.2.tgz",
       "integrity": "sha1-WITKtRLPHTVeP7eE8wgEsrUg23I=",
+      "dev": true,
       "requires": {
         "prelude-ls": "~1.1.2"
       }
@@ -6316,11 +6307,6 @@
           "optional": true
         }
       }
-    },
-    "underscore": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.7.0.tgz",
-      "integrity": "sha1-a7rwh3UA02vjTsqlhODbn+8DUgk="
     },
     "unherit": {
       "version": "1.1.2",
@@ -6600,7 +6586,8 @@
     "word-wrap": {
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.3.tgz",
-      "integrity": "sha512-Hz/mrNwitNRh/HUAtM/VT/5VH+ygD6DV7mYKZAtHOrbs8U7lvPS6xf7EJKMF0uW1KJCl0H701g3ZGus+muE5vQ=="
+      "integrity": "sha512-Hz/mrNwitNRh/HUAtM/VT/5VH+ygD6DV7mYKZAtHOrbs8U7lvPS6xf7EJKMF0uW1KJCl0H701g3ZGus+muE5vQ==",
+      "dev": true
     },
     "wordwrap": {
       "version": "0.0.3",

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
   "dependencies": {
     "chalk": "^3.0.0",
     "commander": "^4.0.1",
-    "jsonpath": "^1.0.2",
+    "jsonpath-plus": "^4.0.0",
     "markdown-spellcheck": "^1.3.1",
     "remark": "^11.0.2",
     "remark-plain-text": "^0.2.0",


### PR DESCRIPTION
## BREAKING CHANGES

Updated results format using `[]` rather than dot notation 

```
// Old
$.paths["/"].get.responses["200"].description
// New
$['paths']['/']['get']['responses'][200]['description']
```

When providing a JSONPath argument, field names must no longer be quoted 

```
// Old
-j "$..['description','title']"
// New
-j "$..[description,title]"
```

## New features

* Extended JSONPath support, including `~` (Resolves #7)